### PR TITLE
Implement expense submission flow

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
     "@nestjs/common": "^10.2.0",
     "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^10.2.0",
+    "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/jwt": "^11.0.1",
     "@nestjs/mapped-types": "^2.0.4",
     "@nestjs/passport": "^11.0.5",

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@nestjs/core':
         specifier: ^10.2.0
         version: 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/event-emitter':
+        specifier: ^3.0.1
+        version: 3.0.1(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)
       '@nestjs/jwt':
         specifier: ^11.0.1
         version: 11.0.1(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))
@@ -626,6 +629,12 @@ packages:
         optional: true
       '@nestjs/websockets':
         optional: true
+
+  '@nestjs/event-emitter@3.0.1':
+    resolution: {integrity: sha512-0Ln/x+7xkU6AJFOcQI9tIhUMXVF7D5itiaQGOyJbXtlAfAIt8gzDdJm+Im7cFzKoWkiW5nCXCPh6GSvdQd/3Dw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
 
   '@nestjs/jwt@11.0.1':
     resolution: {integrity: sha512-HXSsc7SAnCnjA98TsZqrE7trGtHDnYXWp4Ffy6LwSmck1QvbGYdMzBquXofX5l6tIRpeY4Qidl2Ti2CVG77Pdw==}
@@ -1665,6 +1674,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter2@6.4.9:
+    resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
@@ -4117,6 +4129,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@nestjs/event-emitter@3.0.1(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)':
+    dependencies:
+      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      eventemitter2: 6.4.9
+
   '@nestjs/jwt@11.0.1(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))':
     dependencies:
       '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -5342,6 +5360,8 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  eventemitter2@6.4.9: {}
 
   eventemitter3@5.0.1: {}
 

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
@@ -9,9 +10,12 @@ import { MeetsModule } from './meets/meets.module';
 import { OrganizationsModule } from './organizations/organizations.module';
 import { EmailModule } from './email/email.module';
 import { TypesModule } from './types/types.module';
+import { WorkflowsModule } from './workflows/workflows.module';
+import { ExpenseSubmissionsModule } from './expense-submissions/expense-submissions.module';
 
 @Module({
   imports: [
+    EventEmitterModule.forRoot(),
     AuthModule,
     UsersModule,
     HealthModule,
@@ -20,6 +24,8 @@ import { TypesModule } from './types/types.module';
     OrganizationsModule,
     EmailModule,
     TypesModule,
+    WorkflowsModule,
+    ExpenseSubmissionsModule,
   ],
   controllers: [],
   providers: [

--- a/api/src/expense-submissions/expense-submissions.controller.ts
+++ b/api/src/expense-submissions/expense-submissions.controller.ts
@@ -1,0 +1,107 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  UnauthorizedException,
+  UploadedFiles,
+  UseInterceptors,
+} from "@nestjs/common";
+import { FilesInterceptor } from "@nestjs/platform-express";
+import { ApiConsumes, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { User } from "../auth/decorators/user.decorator";
+import { AuthService } from "../auth/auth.service";
+import { UserProfile } from "../users/dto/user-profile.dto";
+import { MeetsService } from "../meets/meets.service";
+import { WorkflowsService } from "../workflows/workflows.service";
+import { ExpenseSubmissionsService } from "./expense-submissions.service";
+
+@ApiTags("Expense Submissions")
+@Controller("meets/:meetId/expense-submissions")
+export class ExpenseSubmissionsController {
+  constructor(
+    private readonly expenseSubmissionsService: ExpenseSubmissionsService,
+    private readonly meetsService: MeetsService,
+    private readonly workflowsService: WorkflowsService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: "List expense submissions for a meet" })
+  async list(
+    @Param("meetId") meetId: string,
+    @User() user?: UserProfile,
+  ) {
+    if (!user) throw new UnauthorizedException();
+    const meet = await this.meetsService.findOne(meetId);
+    if (!this.authService.hasRole(user, meet.organizationId!, "organizer")) {
+      throw new ForbiddenException();
+    }
+    return {
+      submissions: await this.expenseSubmissionsService.listForMeet(meetId),
+    };
+  }
+
+  @Get("workflow-tasks")
+  @ApiOperation({ summary: "List pending workflow tasks for a meet" })
+  async listPendingTasks(
+    @Param("meetId") meetId: string,
+    @User() user?: UserProfile,
+  ) {
+    if (!user) throw new UnauthorizedException();
+    const meet = await this.meetsService.findOne(meetId);
+    if (!this.authService.hasRole(user, meet.organizationId!, "organizer")) {
+      throw new ForbiddenException();
+    }
+    return {
+      tasks: await this.workflowsService.listPendingTasksForMeet(meetId),
+    };
+  }
+
+  @Post()
+  @ApiOperation({ summary: "Submit expenses for a meet" })
+  @ApiConsumes("multipart/form-data")
+  @UseInterceptors(FilesInterceptor("attachments", 10))
+  async create(
+    @Param("meetId") meetId: string,
+    @Body()
+    body: {
+      workflowTaskId: string;
+      notes?: string;
+    },
+    @UploadedFiles() files: Express.Multer.File[] = [],
+    @User() user?: UserProfile,
+  ) {
+    if (!user) throw new UnauthorizedException();
+
+    const meet = await this.meetsService.findOne(meetId);
+    if (!this.authService.hasRole(user, meet.organizationId!, "organizer")) {
+      throw new ForbiddenException();
+    }
+
+    if (!body.workflowTaskId) {
+      throw new BadRequestException("workflowTaskId is required");
+    }
+
+    const tasks = await this.workflowsService.listPendingTasksForMeet(meetId);
+    const task = tasks.find((t) => t.id === body.workflowTaskId);
+    if (!task) {
+      throw new NotFoundException("Workflow task not found or already completed");
+    }
+
+    const submission = await this.expenseSubmissionsService.create(
+      meetId,
+      meet.organizationId!,
+      body.workflowTaskId,
+      user.id,
+      body.notes,
+      files,
+    );
+
+    return { submission };
+  }
+}

--- a/api/src/expense-submissions/expense-submissions.module.ts
+++ b/api/src/expense-submissions/expense-submissions.module.ts
@@ -1,0 +1,26 @@
+import { Module, OnModuleInit } from "@nestjs/common";
+import { DatabaseModule } from "../database/database.module";
+import { AuthModule } from "../auth/auth.module";
+import { MeetsModule } from "../meets/meets.module";
+import { WorkflowsModule } from "../workflows/workflows.module";
+import { WorkflowHandlerRegistry } from "../workflows/workflow-handler.registry";
+import { MinioService } from "../storage/minio.service";
+import { ExpenseSubmissionsService } from "./expense-submissions.service";
+import { ExpenseSubmissionsController } from "./expense-submissions.controller";
+import { ExpenseSubmissionHandler } from "../workflows/handlers/expense-submission.handler";
+
+@Module({
+  imports: [DatabaseModule, AuthModule, MeetsModule, WorkflowsModule],
+  controllers: [ExpenseSubmissionsController],
+  providers: [ExpenseSubmissionsService, MinioService, ExpenseSubmissionHandler],
+})
+export class ExpenseSubmissionsModule implements OnModuleInit {
+  constructor(
+    private readonly registry: WorkflowHandlerRegistry,
+    private readonly handler: ExpenseSubmissionHandler,
+  ) {}
+
+  onModuleInit() {
+    this.registry.register(this.handler);
+  }
+}

--- a/api/src/expense-submissions/expense-submissions.service.ts
+++ b/api/src/expense-submissions/expense-submissions.service.ts
@@ -1,0 +1,147 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { DatabaseService } from "../database/database.service";
+import { MinioService } from "../storage/minio.service";
+import { v4 as uuid } from "uuid";
+
+@Injectable()
+export class ExpenseSubmissionsService {
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly minio: MinioService,
+  ) {}
+
+  async create(
+    meetId: string,
+    organizationId: string,
+    workflowTaskId: string,
+    submittedBy: string,
+    notes: string | undefined,
+    files: Express.Multer.File[],
+  ) {
+    const now = new Date().toISOString();
+
+    const submission = await this.db.getClient().transaction(async (trx) => {
+      const [row] = await trx("expense_submissions")
+        .insert({
+          meet_id: meetId,
+          organization_id: organizationId,
+          workflow_task_id: workflowTaskId,
+          submitted_by: submittedBy,
+          notes: notes ?? null,
+          status: "submitted",
+          submitted_at: now,
+          created_at: now,
+          updated_at: now,
+        })
+        .returning("*");
+
+      if (files.length > 0) {
+        const attachments = await Promise.all(
+          files.map(async (file) => {
+            const extension = file.mimetype.split("/")[1] || "bin";
+            const objectKey = `expense-submissions/${row.id}/${uuid()}.${extension}`;
+            const uploaded = await this.minio.upload(
+              objectKey,
+              file.buffer,
+              file.mimetype,
+            );
+            return {
+              expense_submission_id: row.id,
+              object_key: uploaded.objectKey,
+              url: uploaded.url,
+              filename: file.originalname,
+              content_type: file.mimetype,
+              size_bytes: file.size,
+              created_at: now,
+            };
+          }),
+        );
+        await trx("expense_attachments").insert(attachments);
+      }
+
+      return row;
+    });
+
+    await this.db
+      .getClient()("meet_workflow_tasks")
+      .where({ id: workflowTaskId })
+      .update({ status: "completed", updated_at: new Date().toISOString() });
+
+    return this.findOne(submission.id);
+  }
+
+  async findOne(id: string) {
+    const submission = await this.db
+      .getClient()("expense_submissions")
+      .where({ id })
+      .first();
+    if (!submission) throw new NotFoundException("Expense submission not found");
+
+    const attachments = await this.db
+      .getClient()("expense_attachments")
+      .where({ expense_submission_id: id })
+      .select("id", "url", "filename", "content_type", "size_bytes", "created_at");
+
+    return this.toDto(submission, attachments);
+  }
+
+  async listForMeet(meetId: string) {
+    const submissions = await this.db
+      .getClient()("expense_submissions")
+      .where({ meet_id: meetId })
+      .orderBy("submitted_at", "desc");
+
+    const ids = submissions.map((s: any) => s.id);
+    const attachments =
+      ids.length > 0
+        ? await this.db
+            .getClient()("expense_attachments")
+            .whereIn("expense_submission_id", ids)
+            .select(
+              "id",
+              "expense_submission_id",
+              "url",
+              "filename",
+              "content_type",
+              "size_bytes",
+              "created_at",
+            )
+        : [];
+
+    const bySubmission = attachments.reduce<Record<string, any[]>>(
+      (acc, a: any) => {
+        if (!acc[a.expense_submission_id]) acc[a.expense_submission_id] = [];
+        acc[a.expense_submission_id].push(a);
+        return acc;
+      },
+      {},
+    );
+
+    return submissions.map((s: any) =>
+      this.toDto(s, bySubmission[s.id] ?? []),
+    );
+  }
+
+  private toDto(submission: Record<string, any>, attachments: any[]) {
+    return {
+      id: submission.id,
+      meetId: submission.meet_id,
+      organizationId: submission.organization_id,
+      workflowTaskId: submission.workflow_task_id,
+      submittedBy: submission.submitted_by,
+      notes: submission.notes ?? undefined,
+      status: submission.status,
+      submittedAt: submission.submitted_at,
+      createdAt: submission.created_at,
+      updatedAt: submission.updated_at,
+      attachments: attachments.map((a) => ({
+        id: a.id,
+        url: a.url,
+        filename: a.filename,
+        contentType: a.content_type,
+        sizeBytes: a.size_bytes,
+        createdAt: a.created_at,
+      })),
+    };
+  }
+}

--- a/api/src/meets/meets.controller.ts
+++ b/api/src/meets/meets.controller.ts
@@ -38,6 +38,7 @@ import { UserProfile } from "../users/dto/user-profile.dto";
 import { EmailService } from "../email/email.service";
 import { DatabaseService } from "../database/database.service";
 import * as ExcelJS from "exceljs";
+import { EventEmitter2 } from "@nestjs/event-emitter";
 
 @ApiTags("Meets")
 @Controller("meets")
@@ -48,7 +49,8 @@ export class MeetsController {
     private readonly meetsService: MeetsService,
     private readonly emailService: EmailService,
     private readonly db: DatabaseService,
-    private readonly authService: AuthService
+    private readonly authService: AuthService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   @Get()
@@ -551,6 +553,8 @@ export class MeetsController {
       attachments: [attachment],
       meetId: meet.id,
     });
+
+    this.eventEmitter.emit("meet.report_generated", { meet });
 
     return { status: "sent", to: organizerEmail };
   }

--- a/api/src/workflows/dto/create-workflow.dto.ts
+++ b/api/src/workflows/dto/create-workflow.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from "class-validator";
+
+export class CreateWorkflowDto {
+  @ApiProperty({ example: "Post-meet expenses" })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({ example: "meet.report_generated" })
+  @IsString()
+  @IsNotEmpty()
+  trigger!: string;
+
+  @ApiProperty({ example: "expense_submission" })
+  @IsString()
+  @IsNotEmpty()
+  actionType!: string;
+
+  @ApiProperty({ example: {} })
+  @IsObject()
+  @IsOptional()
+  config?: Record<string, unknown>;
+
+  @ApiProperty({ example: true })
+  @IsBoolean()
+  @IsOptional()
+  enabled?: boolean;
+}

--- a/api/src/workflows/dto/update-workflow.dto.ts
+++ b/api/src/workflows/dto/update-workflow.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsBoolean,
+  IsObject,
+  IsOptional,
+  IsString,
+} from "class-validator";
+
+export class UpdateWorkflowDto {
+  @ApiProperty({ example: "Post-meet expenses" })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiProperty({ example: true })
+  @IsBoolean()
+  @IsOptional()
+  enabled?: boolean;
+
+  @ApiProperty({ example: {} })
+  @IsObject()
+  @IsOptional()
+  config?: Record<string, unknown>;
+}

--- a/api/src/workflows/handlers/expense-submission.handler.ts
+++ b/api/src/workflows/handlers/expense-submission.handler.ts
@@ -1,0 +1,36 @@
+import { Injectable } from "@nestjs/common";
+import { DatabaseService } from "../../database/database.service";
+import {
+  IWorkflowHandler,
+  WorkflowContext,
+} from "./workflow-handler.interface";
+
+@Injectable()
+export class ExpenseSubmissionHandler implements IWorkflowHandler {
+  readonly actionType = "expense_submission";
+
+  constructor(private readonly db: DatabaseService) {}
+
+  async execute(
+    context: WorkflowContext,
+    config: Record<string, unknown>,
+    workflowId: string,
+  ): Promise<void> {
+    const { meet, organizationId } = context;
+
+    await this.db.getClient()("meet_workflow_tasks").insert({
+      meet_id: meet.id,
+      organization_id: organizationId,
+      workflow_id: workflowId,
+      workflow_type: this.actionType,
+      status: "pending",
+      payload: {
+        meetName: meet.name,
+        meetLocation: meet.location ?? null,
+        meetLocationLat: meet.locationLat ?? null,
+        meetLocationLng: meet.locationLong ?? null,
+        config,
+      },
+    });
+  }
+}

--- a/api/src/workflows/handlers/workflow-handler.interface.ts
+++ b/api/src/workflows/handlers/workflow-handler.interface.ts
@@ -1,0 +1,16 @@
+import { MeetDto } from "../../meets/dto/meet.dto";
+
+export interface WorkflowContext {
+  meet: MeetDto;
+  organizationId: string;
+  trigger: string;
+}
+
+export interface IWorkflowHandler {
+  readonly actionType: string;
+  execute(
+    context: WorkflowContext,
+    config: Record<string, unknown>,
+    workflowId: string,
+  ): Promise<void>;
+}

--- a/api/src/workflows/workflow-handler.registry.ts
+++ b/api/src/workflows/workflow-handler.registry.ts
@@ -1,0 +1,15 @@
+import { Injectable } from "@nestjs/common";
+import { IWorkflowHandler } from "./handlers/workflow-handler.interface";
+
+@Injectable()
+export class WorkflowHandlerRegistry {
+  private readonly handlers: IWorkflowHandler[] = [];
+
+  register(handler: IWorkflowHandler) {
+    this.handlers.push(handler);
+  }
+
+  getAll() {
+    return this.handlers;
+  }
+}

--- a/api/src/workflows/workflow-handler.token.ts
+++ b/api/src/workflows/workflow-handler.token.ts
@@ -1,0 +1,1 @@
+export const WORKFLOW_HANDLER = "WORKFLOW_HANDLER";

--- a/api/src/workflows/workflows.controller.ts
+++ b/api/src/workflows/workflows.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { ApiTags } from "@nestjs/swagger";
+import { User } from "../auth/decorators/user.decorator";
+import { AuthService } from "../auth/auth.service";
+import { UserProfile } from "../users/dto/user-profile.dto";
+import { WorkflowsService } from "./workflows.service";
+import { CreateWorkflowDto } from "./dto/create-workflow.dto";
+import { UpdateWorkflowDto } from "./dto/update-workflow.dto";
+
+@ApiTags("Workflows")
+@Controller(["organizations/:orgId/workflows", "organisations/:orgId/workflows"])
+export class WorkflowsController {
+  constructor(
+    private readonly workflowsService: WorkflowsService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Get()
+  async list(@Param("orgId") orgId: string, @User() user?: UserProfile) {
+    if (!user) throw new UnauthorizedException();
+    if (!this.authService.hasRole(user, orgId, "organizer")) {
+      throw new ForbiddenException();
+    }
+    return { workflows: await this.workflowsService.listWorkflows(orgId) };
+  }
+
+  @Post()
+  async create(
+    @Param("orgId") orgId: string,
+    @Body() dto: CreateWorkflowDto,
+    @User() user?: UserProfile,
+  ) {
+    if (!user) throw new UnauthorizedException();
+    if (!this.authService.hasRole(user, orgId, "organizer")) {
+      throw new ForbiddenException();
+    }
+    return { workflow: await this.workflowsService.createWorkflow(orgId, dto) };
+  }
+
+  @Patch(":workflowId")
+  async update(
+    @Param("orgId") orgId: string,
+    @Param("workflowId") workflowId: string,
+    @Body() dto: UpdateWorkflowDto,
+    @User() user?: UserProfile,
+  ) {
+    if (!user) throw new UnauthorizedException();
+    if (!this.authService.hasRole(user, orgId, "organizer")) {
+      throw new ForbiddenException();
+    }
+    return {
+      workflow: await this.workflowsService.updateWorkflow(orgId, workflowId, dto),
+    };
+  }
+
+  @Delete(":workflowId")
+  async remove(
+    @Param("orgId") orgId: string,
+    @Param("workflowId") workflowId: string,
+    @User() user?: UserProfile,
+  ) {
+    if (!user) throw new UnauthorizedException();
+    if (!this.authService.hasRole(user, orgId, "organizer")) {
+      throw new ForbiddenException();
+    }
+    return this.workflowsService.deleteWorkflow(orgId, workflowId);
+  }
+}

--- a/api/src/workflows/workflows.module.ts
+++ b/api/src/workflows/workflows.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { DatabaseModule } from "../database/database.module";
+import { AuthModule } from "../auth/auth.module";
+import { WorkflowsService } from "./workflows.service";
+import { WorkflowsController } from "./workflows.controller";
+import { WorkflowHandlerRegistry } from "./workflow-handler.registry";
+
+@Module({
+  imports: [DatabaseModule, AuthModule],
+  controllers: [WorkflowsController],
+  providers: [WorkflowsService, WorkflowHandlerRegistry],
+  exports: [WorkflowsService, WorkflowHandlerRegistry],
+})
+export class WorkflowsModule {}

--- a/api/src/workflows/workflows.service.ts
+++ b/api/src/workflows/workflows.service.ts
@@ -1,0 +1,163 @@
+import { Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { OnEvent } from "@nestjs/event-emitter";
+import { DatabaseService } from "../database/database.service";
+import { MeetDto } from "../meets/dto/meet.dto";
+import { WorkflowContext } from "./handlers/workflow-handler.interface";
+import { WorkflowHandlerRegistry } from "./workflow-handler.registry";
+import { CreateWorkflowDto } from "./dto/create-workflow.dto";
+import { UpdateWorkflowDto } from "./dto/update-workflow.dto";
+
+@Injectable()
+export class WorkflowsService {
+  private readonly logger = new Logger(WorkflowsService.name);
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly registry: WorkflowHandlerRegistry,
+  ) {}
+
+  @OnEvent("meet.report_generated")
+  async onReportGenerated(payload: { meet: MeetDto }) {
+    await this.dispatch(payload.meet, "meet.report_generated");
+  }
+
+  private async dispatch(meet: MeetDto, trigger: string) {
+    if (!meet.organizationId) return;
+
+    const workflows = await this.db
+      .getClient()("organization_workflows")
+      .where({
+        organization_id: meet.organizationId,
+        trigger,
+        enabled: true,
+      });
+
+    for (const workflow of workflows) {
+      const handler = this.registry.getAll().find(
+        (h) => h.actionType === workflow.action_type,
+      );
+      if (!handler) {
+        this.logger.warn(`No handler for action_type: ${workflow.action_type}`);
+        continue;
+      }
+      const context: WorkflowContext = {
+        meet,
+        organizationId: meet.organizationId,
+        trigger,
+      };
+      try {
+        await handler.execute(context, workflow.config ?? {}, workflow.id);
+      } catch (err) {
+        this.logger.error(
+          `Workflow ${workflow.id} (${workflow.action_type}) failed for meet ${meet.id}`,
+          err,
+        );
+      }
+    }
+  }
+
+  async listWorkflows(orgId: string) {
+    const rows = await this.db
+      .getClient()("organization_workflows")
+      .where({ organization_id: orgId })
+      .orderBy("created_at", "asc");
+    return rows.map(this.toDto);
+  }
+
+  async createWorkflow(orgId: string, dto: CreateWorkflowDto) {
+    const now = new Date().toISOString();
+    const [row] = await this.db
+      .getClient()("organization_workflows")
+      .insert({
+        organization_id: orgId,
+        name: dto.name,
+        trigger: dto.trigger,
+        action_type: dto.actionType,
+        config: dto.config ?? {},
+        enabled: dto.enabled ?? true,
+        created_at: now,
+        updated_at: now,
+      })
+      .returning("*");
+    return this.toDto(row);
+  }
+
+  async updateWorkflow(orgId: string, workflowId: string, dto: UpdateWorkflowDto) {
+    const updates: Record<string, unknown> = {
+      updated_at: new Date().toISOString(),
+    };
+    if (dto.name !== undefined) updates.name = dto.name;
+    if (dto.enabled !== undefined) updates.enabled = dto.enabled;
+    if (dto.config !== undefined) updates.config = dto.config;
+
+    const [row] = await this.db
+      .getClient()("organization_workflows")
+      .where({ id: workflowId, organization_id: orgId })
+      .update(updates)
+      .returning("*");
+    if (!row) throw new NotFoundException("Workflow not found");
+    return this.toDto(row);
+  }
+
+  async deleteWorkflow(orgId: string, workflowId: string) {
+    const deleted = await this.db
+      .getClient()("organization_workflows")
+      .where({ id: workflowId, organization_id: orgId })
+      .del();
+    if (!deleted) throw new NotFoundException("Workflow not found");
+    return { deleted: true };
+  }
+
+  async listPendingTasksForMeet(meetId: string) {
+    const rows = await this.db
+      .getClient()("meet_workflow_tasks")
+      .where({ meet_id: meetId, status: "pending" })
+      .orderBy("created_at", "asc");
+    return rows.map(this.toTaskDto);
+  }
+
+  async dismissTask(meetId: string, taskId: string) {
+    const [row] = await this.db
+      .getClient()("meet_workflow_tasks")
+      .where({ id: taskId, meet_id: meetId })
+      .update({ status: "dismissed", updated_at: new Date().toISOString() })
+      .returning("*");
+    if (!row) throw new NotFoundException("Task not found");
+    return this.toTaskDto(row);
+  }
+
+  async completeTask(taskId: string) {
+    await this.db
+      .getClient()("meet_workflow_tasks")
+      .where({ id: taskId })
+      .update({ status: "completed", updated_at: new Date().toISOString() });
+  }
+
+  private toDto(row: Record<string, any>) {
+    return {
+      id: row.id,
+      organizationId: row.organization_id,
+      name: row.name,
+      trigger: row.trigger,
+      actionType: row.action_type,
+      config: row.config ?? {},
+      enabled: row.enabled,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private toTaskDto(row: Record<string, any>) {
+    return {
+      id: row.id,
+      meetId: row.meet_id,
+      organizationId: row.organization_id,
+      workflowId: row.workflow_id,
+      workflowType: row.workflow_type,
+      status: row.status,
+      payload: row.payload ?? {},
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+}

--- a/db/migrations/20260307120000_create_workflows_and_expense_submissions.ts
+++ b/db/migrations/20260307120000_create_workflows_and_expense_submissions.ts
@@ -1,0 +1,109 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable("organization_workflows", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table
+      .uuid("organization_id")
+      .notNullable()
+      .references("id")
+      .inTable("organizations")
+      .onDelete("CASCADE");
+    table.string("name").notNullable();
+    table.string("trigger").notNullable(); // e.g. 'meet.report_generated'
+    table.string("action_type").notNullable(); // e.g. 'expense_submission'
+    table.jsonb("config").notNullable().defaultTo("{}");
+    table.boolean("enabled").notNullable().defaultTo(true);
+    table.timestamp("created_at", { useTz: true }).defaultTo(knex.fn.now());
+    table.timestamp("updated_at", { useTz: true }).defaultTo(knex.fn.now());
+    table.index(["organization_id"]);
+  });
+
+  await knex.schema.createTable("meet_workflow_tasks", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table
+      .uuid("meet_id")
+      .notNullable()
+      .references("id")
+      .inTable("meets")
+      .onDelete("CASCADE");
+    table
+      .uuid("organization_id")
+      .notNullable()
+      .references("id")
+      .inTable("organizations")
+      .onDelete("CASCADE");
+    table
+      .uuid("workflow_id")
+      .notNullable()
+      .references("id")
+      .inTable("organization_workflows")
+      .onDelete("CASCADE");
+    table.string("workflow_type").notNullable(); // mirrors action_type
+    table.string("status").notNullable().defaultTo("pending"); // pending | completed | dismissed
+    table.jsonb("payload").notNullable().defaultTo("{}");
+    table.timestamp("created_at", { useTz: true }).defaultTo(knex.fn.now());
+    table.timestamp("updated_at", { useTz: true }).defaultTo(knex.fn.now());
+    table.index(["meet_id", "status"]);
+    table.index(["organization_id"]);
+  });
+
+  await knex.schema.createTable("expense_submissions", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table
+      .uuid("meet_id")
+      .notNullable()
+      .references("id")
+      .inTable("meets")
+      .onDelete("CASCADE");
+    table
+      .uuid("organization_id")
+      .notNullable()
+      .references("id")
+      .inTable("organizations")
+      .onDelete("CASCADE");
+    table
+      .uuid("workflow_task_id")
+      .notNullable()
+      .references("id")
+      .inTable("meet_workflow_tasks")
+      .onDelete("CASCADE");
+    table
+      .uuid("submitted_by")
+      .notNullable()
+      .references("id")
+      .inTable("users")
+      .onDelete("CASCADE");
+    table.text("notes").nullable();
+    table.string("status").notNullable().defaultTo("submitted"); // submitted | approved | rejected
+    table.timestamp("submitted_at", { useTz: true }).defaultTo(knex.fn.now());
+    table.timestamp("created_at", { useTz: true }).defaultTo(knex.fn.now());
+    table.timestamp("updated_at", { useTz: true }).defaultTo(knex.fn.now());
+    table.index(["meet_id"]);
+    table.index(["organization_id"]);
+  });
+
+  await knex.schema.createTable("expense_attachments", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table
+      .uuid("expense_submission_id")
+      .notNullable()
+      .references("id")
+      .inTable("expense_submissions")
+      .onDelete("CASCADE");
+    table.string("object_key").notNullable();
+    table.string("url").notNullable();
+    table.string("filename").notNullable();
+    table.string("content_type").notNullable();
+    table.integer("size_bytes").notNullable();
+    table.timestamp("created_at", { useTz: true }).defaultTo(knex.fn.now());
+    table.index(["expense_submission_id"]);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("expense_attachments");
+  await knex.schema.dropTableIfExists("expense_submissions");
+  await knex.schema.dropTableIfExists("meet_workflow_tasks");
+  await knex.schema.dropTableIfExists("organization_workflows");
+}

--- a/db/seeds/004_dev_workflows.ts
+++ b/db/seeds/004_dev_workflows.ts
@@ -1,0 +1,23 @@
+import type { Knex } from "knex";
+
+export async function seed(knex: Knex): Promise<void> {
+  await knex("organization_workflows").del();
+
+  const primaryOrg = await knex("organizations").orderBy("created_at", "asc").first("id");
+  if (!primaryOrg?.id) {
+    throw new Error("Seed requires at least one organization (run user seeds first)");
+  }
+
+  const now = new Date().toISOString();
+
+  await knex("organization_workflows").insert({
+    organization_id: primaryOrg.id,
+    name: "Post-meet expense submission",
+    trigger: "meet.report_generated",
+    action_type: "expense_submission",
+    config: {},
+    enabled: true,
+    created_at: now,
+    updated_at: now,
+  });
+}

--- a/web/src/components/reportsModal/ReportsModal.tsx
+++ b/web/src/components/reportsModal/ReportsModal.tsx
@@ -22,6 +22,7 @@ import { useApi } from "../../hooks/useApi";
 import { useFetchMeetAttendees } from "../../hooks/useFetchMeetAttendees";
 import { useFetchMeet } from "../../hooks/useFetchMeet";
 import MeetStatusEnum from "../../types/MeetStatusEnum";
+import { ExpenseSubmissionModal } from "../workflows/ExpenseSubmissionModal";
 
 type ReportsModalProps = {
   open: boolean;
@@ -34,6 +35,7 @@ export function ReportsModal({ open, onClose, meetId }: ReportsModalProps) {
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const api = useApi();
   const [isGenerating, setIsGenerating] = useState(false);
+  const [pendingExpenseTask, setPendingExpenseTask] = useState<any | null>(null);
   const { data: attendees, isLoading } = useFetchMeetAttendees(
     meetId,
     "accepted"
@@ -70,7 +72,15 @@ export function ReportsModal({ open, onClose, meetId }: ReportsModalProps) {
     setIsGenerating(true);
     try {
       await api.post(`/meets/${meetId}/report`);
-      onClose();
+      const { tasks } = await api.get<{ tasks: any[] }>(
+        `/meets/${meetId}/expense-submissions/workflow-tasks`,
+      );
+      const expenseTask = tasks.find((t) => t.workflowType === "expense_submission");
+      if (expenseTask) {
+        setPendingExpenseTask(expenseTask);
+      } else {
+        onClose();
+      }
     } finally {
       setIsGenerating(false);
     }
@@ -98,6 +108,23 @@ export function ReportsModal({ open, onClose, meetId }: ReportsModalProps) {
     p: fullScreen ? 2 : 3,
     outline: "none",
   };
+
+  if (pendingExpenseTask) {
+    return (
+      <ExpenseSubmissionModal
+        open={true}
+        task={pendingExpenseTask}
+        onClose={() => {
+          setPendingExpenseTask(null);
+          onClose();
+        }}
+        onSubmitted={() => {
+          setPendingExpenseTask(null);
+          onClose();
+        }}
+      />
+    );
+  }
 
   return (
     <Modal open={open} onClose={onClose}>

--- a/web/src/components/workflows/ExpenseSubmissionModal.tsx
+++ b/web/src/components/workflows/ExpenseSubmissionModal.tsx
@@ -1,0 +1,256 @@
+import {
+  Box,
+  Button,
+  CircularProgress,
+  DialogActions,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Modal,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import AttachFileIcon from "@mui/icons-material/AttachFile";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import { useRef, useState } from "react";
+import { useApi } from "../../hooks/useApi";
+
+type WorkflowTask = {
+  id: string;
+  meetId: string;
+  workflowType: string;
+  payload: {
+    meetName?: string;
+    meetLocation?: string;
+    meetLocationLat?: number;
+    meetLocationLng?: number;
+  };
+};
+
+type ExpenseSubmissionModalProps = {
+  open: boolean;
+  task: WorkflowTask;
+  onClose: () => void;
+  onSubmitted: () => void;
+};
+
+export function ExpenseSubmissionModal({
+  open,
+  task,
+  onClose,
+  onSubmitted,
+}: ExpenseSubmissionModalProps) {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const api = useApi();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [notes, setNotes] = useState("");
+  const [attachments, setAttachments] = useState<File[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAddFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    setAttachments((prev) => [...prev, ...files]);
+    e.target.value = "";
+  };
+
+  const handleRemoveFile = (index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const formData = new FormData();
+      formData.append("workflowTaskId", task.id);
+      if (notes.trim()) formData.append("notes", notes.trim());
+      attachments.forEach((file) => formData.append("attachments", file));
+
+      const token =
+        typeof window !== "undefined"
+          ? window.localStorage.getItem("accessToken")
+          : null;
+
+      const res = await fetch(
+        `${api.baseUrl}/meets/${task.meetId}/expense-submissions`,
+        {
+          method: "POST",
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          body: formData,
+        },
+      );
+
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || "Submission failed");
+      }
+
+      onSubmitted();
+    } catch (err: any) {
+      setError(err.message ?? "Something went wrong");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const modalStyles = {
+    position: "absolute" as const,
+    top: fullScreen ? 0 : "50%",
+    left: fullScreen ? 0 : "50%",
+    transform: fullScreen ? "none" : "translate(-50%, -50%)",
+    width: fullScreen ? "100%" : 560,
+    height: fullScreen ? "100%" : "auto",
+    maxHeight: fullScreen ? "100%" : "85vh",
+    p: fullScreen ? 2 : 3,
+    outline: "none",
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Box sx={modalStyles}>
+        <Paper
+          elevation={3}
+          sx={{
+            height: "100%",
+            maxHeight: "inherit",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ p: 2, borderBottom: `1px solid ${theme.palette.divider}` }}
+          >
+            <Typography variant="h6">Submit expenses</Typography>
+          </Stack>
+
+          <Box sx={{ p: 2, overflow: "auto", flex: 1 }}>
+            <Stack spacing={2}>
+              {task.payload.meetLocation && (
+                <Box
+                  sx={{
+                    p: 1.5,
+                    borderRadius: 1,
+                    bgcolor: theme.palette.action.hover,
+                  }}
+                >
+                  <Typography variant="body2" color="text.secondary">
+                    Meet location
+                  </Typography>
+                  <Typography variant="body2">
+                    {task.payload.meetLocation}
+                  </Typography>
+                </Box>
+              )}
+
+              <TextField
+                label="Notes"
+                multiline
+                minRows={3}
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Describe expenses, mileage details, etc."
+                fullWidth
+              />
+
+              <Box>
+                <Stack
+                  direction="row"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  mb={1}
+                >
+                  <Typography variant="body2" fontWeight={500}>
+                    Attachments
+                  </Typography>
+                  <Button
+                    size="small"
+                    startIcon={<AttachFileIcon />}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    Add files
+                  </Button>
+                </Stack>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  hidden
+                  onChange={handleAddFiles}
+                />
+                {attachments.length === 0 ? (
+                  <Typography variant="body2" color="text.secondary">
+                    No attachments added.
+                  </Typography>
+                ) : (
+                  <List dense disablePadding>
+                    {attachments.map((file, index) => (
+                      <ListItem
+                        key={index}
+                        disablePadding
+                        secondaryAction={
+                          <IconButton
+                            edge="end"
+                            size="small"
+                            onClick={() => handleRemoveFile(index)}
+                          >
+                            <DeleteOutlineIcon fontSize="small" />
+                          </IconButton>
+                        }
+                      >
+                        <ListItemText
+                          primary={file.name}
+                          secondary={`${(file.size / 1024).toFixed(1)} KB`}
+                          primaryTypographyProps={{ variant: "body2" }}
+                          secondaryTypographyProps={{ variant: "caption" }}
+                        />
+                      </ListItem>
+                    ))}
+                  </List>
+                )}
+              </Box>
+
+              {error && (
+                <Typography variant="body2" color="error">
+                  {error}
+                </Typography>
+              )}
+            </Stack>
+          </Box>
+
+          <DialogActions
+            sx={{
+              px: 2,
+              py: 1.5,
+              borderTop: `1px solid ${theme.palette.divider}`,
+            }}
+          >
+            <Button onClick={onClose} disabled={isSubmitting}>
+              Skip
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              startIcon={
+                isSubmitting ? <CircularProgress size={16} /> : undefined
+              }
+            >
+              Submit expenses
+            </Button>
+          </DialogActions>
+        </Paper>
+      </Box>
+    </Modal>
+  );
+}


### PR DESCRIPTION
This change aims to add a custom workflow to the post-meet flow which allows MCSA leaders to submit expenses.
The aim is to keep the expense flow separate from the common flow as far as possible and to make these type of workflows as pluggable and extensible as possible.

At the moment the expense report is just persisted to the db, but the idea would be that it would post it to a MCSA API/webhook somewhere.

I obviously don't have much experience with typescript so this was mostly done with Claude as a POC. 
If this approach is something that you agree with, I can flesh it out a bit more, test it etc.
Let me know.